### PR TITLE
option to install_latest() from CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,6 +15,7 @@
 ^cran-comments\.md$
 ^pkgdown$
 ^_pkgdown$
+^_pkgdown.yml$
 ^\.httr-oauth$
 ^CRAN-RELEASE$
 tests\^spelling

--- a/R/install_easystats.R
+++ b/R/install_easystats.R
@@ -11,18 +11,19 @@ CRAN_checks <- function() {
 }
 
 
-#' Install the easystats suite from GitHub or CRAN
+#' Install the easystats suite from R-universe (GitHub) or CRAN
 #'
-#' This function can be used to install all the easystats packages from either
-#' GitHub (for the latest develolpment versions) or from CRAN (for the current
-#' version on CRAN), If installed from GitHub, packages will be installed from
-#' the stable branch (master/main) for each package.
+#' This function can be used to install all the easystats packages, either
+#' latest develolpment versions (from R-universe/GitHub) or the current
+#' versions from CRAN. If the development versions are installed, packages
+#' will be installed from the stable branch (master/main) for each package.
 #'
-#' @param source Character. Either `"github"` or `"cran"`. If `"cran"`, packages will be installed from the default CRAN mirror returned by `getOption("repos")$CRAN`.
+#' @param source Character. Either `"development"` or `"cran"`. If `"cran"`, packages will be installed from the default CRAN mirror returned by `getOption("repos")$CRAN`.
 #'
 #' @export
-install_latest <- function(source = c("github", "cran")) {
-  if (source == "github") {
+install_latest <- function(source = c("development", "cran")) {
+  source <- match.arg(source, c("development", "cran"))
+  if (source == "development") {
     repos <- "https://easystats.r-universe.dev"
   } else {
     repos <- getOption("repos")['CRAN']

--- a/R/install_easystats.R
+++ b/R/install_easystats.R
@@ -11,19 +11,28 @@ CRAN_checks <- function() {
 }
 
 
-#' Install the easystats suite from github
+#' Install the easystats suite from GitHub or CRAN
 #'
-#' This function can be used to install all the easystats packages from GitHub,
-#' either from the master/main branch (the stable one) with
-#' \code{install_easystats_latest()}.
+#' This function can be used to install all the easystats packages from either
+#' GitHub (for the latest develolpment versions) or from CRAN (for the current
+#' version on CRAN), If installed from GitHub, packages will be installed from
+#' the stable branch (master/main) for each package.
+#'
+#' @param source Character. Either `"github"` or `"cran"`. If `"cran"`, packages will be installed from the default CRAN mirror returned by `getOption("repos")$CRAN`.
 #'
 #' @export
-install_latest <- function() {
+install_latest <- function(source = c("github", "cran")) {
+  if (source == "github") {
+    repos <- "https://easystats.r-universe.dev"
+  } else {
+    repos <- getOption("repos")['CRAN']
+  }
+
   install.packages(c(
     "insight", "datawizard", "bayestestR", "performance",
     "parameters", "effectsize", "correlation", "modelbased",
     "see", "report"
-  ), repos = "https://easystats.r-universe.dev")
+  ), repos = repos)
 }
 
 

--- a/R/install_easystats.R
+++ b/R/install_easystats.R
@@ -28,7 +28,7 @@ install_latest <- function(source = c("github", "cran")) {
     repos <- getOption("repos")['CRAN']
   }
 
-  install.packages(c(
+  utils::install.packages(c(
     "insight", "datawizard", "bayestestR", "performance",
     "parameters", "effectsize", "correlation", "modelbased",
     "see", "report"

--- a/man/install_latest.Rd
+++ b/man/install_latest.Rd
@@ -2,16 +2,16 @@
 % Please edit documentation in R/install_easystats.R
 \name{install_latest}
 \alias{install_latest}
-\title{Install the easystats suite from GitHub or CRAN}
+\title{Install the easystats suite from R-universe (GitHub) or CRAN}
 \usage{
-install_latest(source = c("github", "cran"))
+install_latest(source = c("development", "cran"))
 }
 \arguments{
-\item{source}{Character. Either `"github"` or `"cran"`. If `"cran"`, packages will be installed from the default CRAN mirror returned by `getOption("repos")$CRAN`.}
+\item{source}{Character. Either `"development"` or `"cran"`. If `"cran"`, packages will be installed from the default CRAN mirror returned by `getOption("repos")$CRAN`.}
 }
 \description{
-This function can be used to install all the easystats packages from either
-GitHub (for the latest develolpment versions) or from CRAN (for the current
-version on CRAN), If installed from GitHub, packages will be installed from
-the stable branch (master/main) for each package.
+This function can be used to install all the easystats packages, either 
+latest develolpment versions (from R-universe/GitHub) or the current 
+versions from CRAN. If the development versions are installed, packages 
+will be installed from the stable branch (master/main) for each package.
 }

--- a/man/install_latest.Rd
+++ b/man/install_latest.Rd
@@ -2,12 +2,16 @@
 % Please edit documentation in R/install_easystats.R
 \name{install_latest}
 \alias{install_latest}
-\title{Install the easystats suite from github}
+\title{Install the easystats suite from GitHub or CRAN}
 \usage{
-install_latest()
+install_latest(source = c("github", "cran"))
+}
+\arguments{
+\item{source}{Character. Either `"github"` or `"cran"`. If `"cran"`, packages will be installed from the default CRAN mirror returned by `getOption("repos")$CRAN`.}
 }
 \description{
-This function can be used to install all the easystats packages from GitHub,
-either from the master/main branch (the stable one) with
-\code{install_easystats_latest()}.
+This function can be used to install all the easystats packages from either
+GitHub (for the latest develolpment versions) or from CRAN (for the current
+version on CRAN), If installed from GitHub, packages will be installed from
+the stable branch (master/main) for each package.
 }


### PR DESCRIPTION
I frequently want to revert to CRAN versions for testing. This enables that easily.