### PR TITLE
Show more precise debugging steps

### DIFF
--- a/R/model_dashboard.R
+++ b/R/model_dashboard.R
@@ -71,6 +71,8 @@ model_dashboard <- function(model,
                             rmd_dir = system.file("templates/easydashboard.Rmd", package = "easystats")) {
   insight::check_if_installed(c("DT", "flexdashboard"))
 
+  model_name <- substitute(model)
+
   # render report into HTML
   suppressWarnings(
     rmarkdown::render(
@@ -85,6 +87,7 @@ model_dashboard <- function(model,
       intermediates_dir = output_dir,
       params = list(
         model = model,
+        model_name = model_name,
         check_model_args = check_model_args,
         parameters_args = parameters_args,
         performance_args = performance_args

--- a/inst/templates/easydashboard.Rmd
+++ b/inst/templates/easydashboard.Rmd
@@ -13,6 +13,7 @@ output:
         google: JetBrains Mono
 params:
   model: model
+  model_name: model_name
   check_model_args: check_model_args
   parameters_args: parameters_args
   performance_args: performance_args
@@ -69,12 +70,23 @@ check_model_args <- c(list(model), params$check_model_args)
 if (is.null(check_model_args$verbose)) check_model_args$verbose <- FALSE
 tryCatch(
   {
+    log("a")
     do.call(performance::check_model, check_model_args)
   },
   error = function(e) {
+    check_model_args[[1]] <- NULL
+    if (length(check_model_args) > 0) {
+      args <- vector(length = length(check_model_args))
+      for (i in seq_along(check_model_args)) {
+        args[i] <- paste(",", names(check_model_args)[i], "=", check_model_args[[i]])
+      } 
+    } else {
+      args <- ""
+    }
+    code_to_run <- paste0("performance::check_model(", params$model_name, paste(args, collapse = ""), ")")
+    
     cat(insight::format_message(
-      "\nSomething did not work as expected. Please file an issue at {.url https://github.com/easystats/easystats/issues/} and post the following output:",
-      paste0("\n`", e$message, "`")
+      "\nSomething did not work as expected. Try to run the following code:\n", code_to_run, "\nIf there is an error, please file an issue at {.url https://github.com/easystats/performance/issues/} with the output of the code above. If you don't have an error in R, please file an issue at {.url https://github.com/easystats/easystats/issues/} and post the following output:\n", e$message
     ))
   }
 )


### PR DESCRIPTION
This is related to #283. It is not at all complete, I just did a small test on the "Assumption checks" part to see how to customize the error message to give more precise steps. I implemented an error manually (`log("a")`) just to simulate an error.
```r
foo <- lm(mpg ~ drat, mtcars)
model_dashboard(foo, check_model_args = list(show_dots = FALSE))
```
Here's the current output:

![image](https://user-images.githubusercontent.com/52219252/187750152-ade7bf2b-063d-4f9b-abab-5aade4743cd1.png)

And here's the new type of error messages:

![image](https://user-images.githubusercontent.com/52219252/187750750-3fd15b14-1f92-4207-8207-b097aa3a26a8.png)

@easystats/core-team What do you think? Should it be generalized to the other parts of the dashboard?